### PR TITLE
fix: update domain URLs to sakuyado.fukudev.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Higher scores = better value for money! 🌸
 
 ### 🌐 Vercel (Recommended)
 
-Simply visit: **<https://saku-yado.vercel.app/>**
+Simply visit: **<https://sakuyado.fukudev.org/>**
 
 ### 💻 Local Development
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     title: "SakuYado - Hotel Value Analyzer",
     description:
       "Compare hotels based on review-per-price ratio to get the most value for your money with SakuYado",
-    url: "https://saku-yado.vercel.app",
+    url: "https://sakuyado.fukudev.org",
     siteName: "SakuYado",
     images: [
       {
@@ -57,7 +57,7 @@ const organizationStructuredData = {
   alternateName: "SakuYado Hotel Value Analyzer",
   description:
     "Compare hotels based on review-per-price ratio to get the most value for your money with SakuYado",
-  url: "https://saku-yado.vercel.app",
+  url: "https://sakuyado.fukudev.org",
   applicationCategory: "TravelApplication",
   operatingSystem: "Any",
   browserRequirements: "Requires JavaScript",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -18,7 +18,7 @@
 import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = "https://saku-yado.vercel.app";
+  const baseUrl = "https://sakuyado.fukudev.org";
 
   return {
     rules: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,7 +18,7 @@
 import { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://saku-yado.vercel.app";
+  const baseUrl = "https://sakuyado.fukudev.org";
 
   return [
     {

--- a/src/utils/structured-data.ts
+++ b/src/utils/structured-data.ts
@@ -24,11 +24,11 @@ export function generateAddHotelPageSchema() {
     name: "Add Hotel Information - SakuYado",
     description:
       "Add hotel details to compare value and find the best accommodation deals with SakuYado",
-    url: "https://saku-yado.vercel.app/hotels/add",
+    url: "https://sakuyado.fukudev.org/hotels/add",
     isPartOf: {
       "@type": "WebSite",
       name: "SakuYado",
-      url: "https://saku-yado.vercel.app",
+      url: "https://sakuyado.fukudev.org",
     },
     mainEntity: {
       "@type": "WebApplication",
@@ -45,7 +45,7 @@ export function generateAddHotelPageSchema() {
     },
     potentialAction: {
       "@type": "UseAction",
-      target: "https://saku-yado.vercel.app/hotels/compare",
+      target: "https://sakuyado.fukudev.org/hotels/compare",
       name: "Compare Hotels with SakuYado",
     },
   };


### PR DESCRIPTION
## Summary
- Update all domain references from `saku-yado.vercel.app` to `sakuyado.fukudev.org`
- Updated SEO metadata, OpenGraph URLs, sitemap, robots.txt, and structured data
- Ensures all references point to the new production domain

## Test plan
- [ ] Verify sitemap generates correctly at `/sitemap.xml`
- [ ] Check robots.txt configuration at `/robots.txt`
- [ ] Validate OpenGraph metadata in browser dev tools
- [ ] Confirm structured data schema URLs are correct

🤖 Generated with [Claude Code](https://claude.ai/code)